### PR TITLE
Prevent duplicate symbol definitions

### DIFF
--- a/ryosmk/libroccatryosmk/ryos_device.h
+++ b/ryosmk/libroccatryosmk/ryos_device.h
@@ -22,9 +22,7 @@
 
 G_BEGIN_DECLS
 
-enum {
-	RYOS_WRITE_CHECK_WAIT_LIGHT_CONTROL = 10,
-} RyosWriteCheckWait;
+#define RYOS_WRITE_CHECK_WAIT_LIGHT_CONTROL 10
 
 /*
  * write selection: (before profile specific read)


### PR DESCRIPTION
Change a symbol which defines a _number of milliseconds_ from an enum
constant to a preprocessor macro. This is semantically more correct in
my opinion.
The change particularly helps linking the binary when compiled with GCC
with -fno-common (see
<https://gcc.gnu.org/gcc-10/porting_to.html#common>) as there are no
more duplicate definitions.